### PR TITLE
:recycle: refactor: context API, 로컬 스토리지 관리, getUserProfile, updatePr…

### DIFF
--- a/src/api/authAPI.js
+++ b/src/api/authAPI.js
@@ -11,10 +11,22 @@ export const handleUserLogin = async (userData) => {
   return response.data;
 };
 
-// export const getUserProfile = async (token) => {
-  
-// };
+export const getUserProfile = async (token) => {
+  const response = await USER_API.get("/user", {
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: `Bearer ${token}`,
+    },        
+  })
+  return response.data;
+};
 
-// export const updateProfile = async (formData) => {
-
-// };
+export const updateProfile = async (formData, token) => {
+  const response = await USER_API.patch("/profile", formData, {
+    headers: {
+      Authorization: `Bearer ${token}`,
+      "Content-Type": "multipart/form-data",
+    },
+  })
+  return response.data;
+};

--- a/src/components/TestResultItem.jsx
+++ b/src/components/TestResultItem.jsx
@@ -1,25 +1,22 @@
-import { AuthContext } from "@/context/AuthContext"
 import { getFormattedTime } from "@/utils/dateResult"
 import { mbtiResult } from "@/utils/mbtiResult"
-import { useContext } from "react"
 import styled from "styled-components"
 
-const TestResultItem = ({ data, onDelete, onUpdate }) => {
-  const { user } = useContext(AuthContext);
+const TestResultItem = ({ data, loginUser, onDelete, onUpdate }) => {
   
-  // console.log("data.visi =>",data.visibility );
-  // console.log("user.id =>", user.id );
-  // console.log("data.userId =>", data.userId );
+  console.log("data.userId ===>", data.userId, "loginUser id ===>", loginUser.id);
+
+  if(!data) return false
 
   // 공개 글 || 나의 글
-  if(data.visibility || user.id === data.userId) {
+  if(data.visibility || loginUser) {
     return (
       <StMbtiItem>
         <div className="info">
           <p>
             {data.nickname ? data.nickname : data.userId}        
             {
-              user.id === data.userId && (
+              loginUser.id === data.userId && (
                 <span className={data.visibility ? `listState release` : `listState private` }>
                   {data.visibility ? '공개 글' : '비공개 글'}
                 </span>
@@ -35,7 +32,7 @@ const TestResultItem = ({ data, onDelete, onUpdate }) => {
         
         
         {
-          user.id === data.userId && (
+          loginUser.id === data.userId && (
             <div className="btnArea">
               <button onClick={() => onDelete(data.id)}>삭제</button>
               <button onClick={() => onUpdate({id: data.id, vis: data.visibility})}>

--- a/src/components/TestResultList.jsx
+++ b/src/components/TestResultList.jsx
@@ -2,35 +2,51 @@ import TestResultItem from "./TestResultItem"
 import { useMbti } from "@/hooks/queries";
 import { useDeleteMbti, useVisibilityMbti } from "@/hooks/mutations";
 import styled from "styled-components";
+import { useEffect } from "react";
+import { getUserProfile } from "@/api/authAPI";
+import { useState } from "react";
 
 const TestResultList = () => {  
-  
+  const [loginUser, setLoginUser] = useState({});
   const { data, isLoading, isError } = useMbti();
+
   // custom hooks
   const { mutate: onDeleteMbti } = useDeleteMbti();
   const { mutate: onUpdateMbti } = useVisibilityMbti();
 
-  console.log(data);
+  useEffect(() => {
+    const getProfile = async () => {
+      try{
+        const token = localStorage.getItem("accessToken");
+        const userProfile = await getUserProfile(token);
+        setLoginUser(userProfile);
+      }catch(e){
+        alert("유저의 정보가 없습니다.", e)
+      }
+    }
+    getProfile();
+  }, [isLoading, isError])
 
   if(isLoading) return <div>로딩중입니다.</div>
   if(isError) return <div>에러가 발견되었습니다.</div>
 
   const sortData = data.sort((a, b) => new Date(b.date) - new Date(a.date));   
-  console.log("sortData =>>>", sortData);
+  
   return (
     <StResultItemWrap>
       {
-      sortData.map(list => {
-        return (
-          <TestResultItem 
-            key={list.id}
-            data={list}
-            onDelete={onDeleteMbti}
-            onUpdate={onUpdateMbti}
-          />
-        )
-      })  
-    }   
+        sortData.map(list => {
+          return (
+            <TestResultItem 
+              key={list.id}
+              data={list}
+              loginUser={loginUser}
+              onDelete={onDeleteMbti}
+              onUpdate={onUpdateMbti}
+            />
+          )
+        })  
+      }   
     </StResultItemWrap>    
   )
 }

--- a/src/context/AuthContext.jsx
+++ b/src/context/AuthContext.jsx
@@ -1,51 +1,28 @@
 import { useState } from "react";
 import { createContext } from "react";
 
-
 export const AuthContext = createContext();
 
 const token = localStorage.getItem("accessToken");
-
-const loginUserId = localStorage.getItem("userId");
-const loginUserNickname = localStorage.getItem("nickname");
-
 const saveStorage = (key , value) => localStorage.setItem(key, value);
 const removeStorage = key => localStorage.removeItem(key);
 
 export const AuthProvider = ({ children }) => {
-  const [isLogin, setLogin] = useState(!!token);
-  const [user, setUser] = useState({
-    id: loginUserId || null,
-    nickname: loginUserNickname || null
-  })
-
-  const saveUserInfo = (info) => {
-    saveStorage("userId", info.userId);
-    saveStorage("userNickname", info.nickname);
-    setUser({
-      id: info.userId,
-      nickname: info.nickname,
-    });    
-  }
+  const [isLogin, setIsLogin] = useState(!!token);
 
   const login = (token) => {
     saveStorage("accessToken", token);
-    setLogin(true);
+    setIsLogin(true);
   }
 
   const logout = () => {
     removeStorage("accessToken");
-    removeStorage("userId");
-    removeStorage("userNickname");
-    setLogin(false);
+    setIsLogin(false);
   }
 
   return (
     <AuthContext.Provider value={{
       isLogin,
-      user,
-      saveUserInfo,
-      setLogin,
       login,
       logout
     }}>
@@ -54,3 +31,5 @@ export const AuthProvider = ({ children }) => {
   )
 }
 
+// 훅의 랜더링 주기
+// 컴포넌트 랜더링 주기

--- a/src/hooks/queries.jsx
+++ b/src/hooks/queries.jsx
@@ -1,8 +1,8 @@
 import { getTestResults } from "@/api/mbtiAPI";
-// import { QUERY_KEYS } from "@/constants/queryKeys";
+import { QUERY_KEYS } from "@/constants/queryKeys";
 import { useQuery } from "@tanstack/react-query";
 
 export const useMbti = () => useQuery({
-  queryKey: ["mbti"],
+  queryKey: [QUERY_KEYS.MBTI],
   queryFn: getTestResults,
 })

--- a/src/pages/Join.jsx
+++ b/src/pages/Join.jsx
@@ -5,20 +5,21 @@ import JoinImg from "@/assets/img/bg-mbti3.png";
 import styled from "styled-components";
 
 const Join = () => {
-
-  const [id, setId] = useState("");
-  const [password, setPassword] = useState("");
-  const [nickname, setNickname] = useState("");
+  const [id, setId] = useState(""); // 회원가입 아이디
+  const [password, setPassword] = useState(""); // 회원가입 비밀번호
+  const [nickname, setNickname] = useState(""); // 회원가입 닉네임
   const navigate = useNavigate();
 
   const handleJoin = async (e) => {
     e.preventDefault();
     try{
+      // 작성한 값
       const joinData = {
         id,
         password,
         nickname
       }
+      // 해당 함수를 통해 데이터를 db에 전송함
       const response = await handleUserRegister(joinData);
       if(response.success) {
         alert("회원가입이 완료되었습니다. 로그인 페이지로 이동합니다.")
@@ -61,6 +62,7 @@ const Join = () => {
         <input 
           type="password" 
           name="password"
+          autoComplete="off" 
           value={password} 
           placeholder="비밀번호를 입력하세요!"
           onChange={(e) => setPassword(e.target.value)}

--- a/src/pages/Login.jsx
+++ b/src/pages/Login.jsx
@@ -6,10 +6,11 @@ import LoginImg from "@/assets/img/bg-mbti1.jpg";
 import styled from "styled-components";
 
 const Login = () => {
-  const [id, setId] = useState("");
-  const [password, setPassword] = useState("");
+  const [id, setId] = useState(""); // 로그인 아이디
+  const [password, setPassword] = useState(""); // 로그인 비밀번호
   const navigate = useNavigate();
-  const { login, saveUserInfo } = useContext(AuthContext);
+
+  const { login } = useContext(AuthContext);
 
   const handleLogin = async (e) => {
     e.preventDefault();
@@ -17,9 +18,8 @@ const Login = () => {
       const loginData = { id, password }
       const response = await handleUserLogin(loginData);
       if(response.success){        
-        alert("로그인되었습니다. 메인 페이지로 이동합니다.")
-        login(response.accessToken);
-        saveUserInfo(response);
+        alert("로그인되었습니다. 메인 페이지로 이동합니다.");
+        login(response.accessToken);        
         navigate("/");
       }
     }catch(e){
@@ -42,7 +42,7 @@ const Login = () => {
         <img src={LoginImg} alt="" />
       </div>
       <input type="text" value={id} placeholder="아이디를 입력하세요!" onChange={(e) => setId(e.target.value)}/>
-      <input type="password" value={password} placeholder="비밀번호를 입력하세요!" onChange={(e) => setPassword(e.target.value)}/>
+      <input type="password" value={password} placeholder="비밀번호를 입력하세요!" autoComplete="off"  onChange={(e) => setPassword(e.target.value)}/>
       <button>로그인</button>
     </StForm>
   )

--- a/src/shared/Router.jsx
+++ b/src/shared/Router.jsx
@@ -1,12 +1,9 @@
 import { BrowserRouter, Route, Routes } from "react-router-dom"
-import { AuthContext } from "@/context/AuthContext"
-import { useContext, useState } from "react"
 import Layout from "@/components/Layout"
 import Join from "@/pages/Join"
 import Login from "@/pages/Login"
 import Main from "@/pages/Main"
 import Mypage from "@/pages/Mypage"
-import { useEffect } from "react"
 import ProtectedRoute from "@/components/ProtectedRoute"
 import Test from "@/pages/TestPage"
 import TestResultPage from "@/pages/TestResultPage"
@@ -15,14 +12,6 @@ import TestResultPage from "@/pages/TestResultPage"
 
 
 const Router = () => {
-  const { isLogin } = useContext(AuthContext); // 로그인 상태 확인
-  const [user, setUser] = useState(null);
-  
-  useEffect(() => {
-    setUser(isLogin); // isLogin 변경될 때 user 업데이트
-  }, [isLogin]); 
-
-  console.log("user =>", user);
   return (
     <BrowserRouter>
       <Layout>


### PR DESCRIPTION
…ofile 추가

- 이전에 getUserProfile 을 사용하지 않아서 로그인 할 때 id,nickname,token 값을 로컬 스토리지에 저장하여 관리함.
- 현재 회원 DB를 공유하다보니 다른 MBTI테스트 웹 페이지에서 회원 정보를 수정해도 나의 웹 페이지에서 반영이 안되었음
- 스토리지를 사용해도 json-server에 로그인된 사람의 아이디,닉네임을 전달하기에 오류가 없었던 것 처럼 보였지만 회원 프로필 수정 후 리스트에 노출했을 때 변경이 되지않아서 수정을 진행함